### PR TITLE
Update OpenPGP.js from 6.1.0 to 6.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@vueuse/core": "^12.2.0",
     "markdown-it-footnote": "^4.0.0",
     "moment": "^2.30.1",
-    "openpgp": "^6.0.1",
+    "openpgp": "^6.1.1",
     "vitepress": "^1.5.0",
     "vue-toast-notification": "^3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -964,10 +964,10 @@ oniguruma-to-es@^3.1.0:
     regex "^6.0.1"
     regex-recursion "^6.0.2"
 
-openpgp@^6.0.1:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/openpgp/-/openpgp-6.1.0.tgz#69210cf80f845eb52cde76ecdd82769d2632880c"
-  integrity sha512-fRTeitP+hoGJD3kbdUlAI++wE6MvfvXw1rBqHwmBMxIpLjowatJ2zb5ThkORpIkSz5F12wO+xCYRSTbT7M4qKA==
+openpgp@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/openpgp/-/openpgp-6.1.1.tgz#7f565492f8d243cd5e07181bcc56f07f21ac0608"
+  integrity sha512-V/DXZ5AGCz3q4X8psUSc3q4SxnH/bfICaTSpNcla7wvBFhrxa9/ajm31rtMwZ1qj7Fu2oMpfX6ZcxKmTBlb6Yg==
 
 perfect-debounce@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
CVE-2025-47934 https://github.com/advisories/GHSA-8qff-qr5q-5pr8